### PR TITLE
better Ansible abstractions

### DIFF
--- a/app/scripts/ansible/reporters.coffee
+++ b/app/scripts/ansible/reporters.coffee
@@ -6,10 +6,15 @@ angular.module('ansible')
   'ansible'
   'AMessage'
   ($interval, ansible, AMessage) ->
+
+    # used for not sending redundant gamepad state
+    previousTimestamp = 0
     update = ->
       g = navigator.getGamepads()[0]
-      if not g?
+      if not g? or g.timestamp == previousTimestamp
         return # we don't have anything to send
+
+      previousTimestamp = g.timestamp
 
       content =
         axes: g.axes
@@ -18,5 +23,5 @@ angular.module('ansible')
       message = new AMessage('gamepad', content)
       ansible.send(message)
 
-    $interval(update, 100)
+    $interval(update, 20) # fastest practical for gamepad api
   ]

--- a/app/scripts/support/debug.coffee
+++ b/app/scripts/support/debug.coffee
@@ -15,6 +15,9 @@ angular.module('debug', ['ansible'])
         value: process.arch
       ]
 
+    $scope.validGamepad = ->
+      return _.filter(navigator.getGamepads(), (x) -> x?)
+
     $scope.lastMessage = 'None'
     ansible.on('message', (msg) ->
       console.log('ansible received messages')

--- a/griff/ansible.py
+++ b/griff/ansible.py
@@ -57,11 +57,15 @@ def send(msg):
     send_queue.put_nowait(msg)
 
 # Receives a message, or None if there is no current message.
-def recv():
-    try:
-        return recv_queue.get_nowait()
-    except Empty:
-        return None
+# If block is True, blocks.
+def recv(block=False):
+    if block:
+        return recv_queue.get()
+    else:
+        try:
+            return recv_queue.get_nowait()
+        except Empty:
+            return None
 
 # Intialize on module import
 send_port = 12355

--- a/griff/socket_bridge/app.js
+++ b/griff/socket_bridge/app.js
@@ -5,8 +5,14 @@ var ansible = require('./ansible');
 io.on('connection', function (socket) {
   console.log('Socket.io connected.');
   ansible.on('message', function (data) {
-    socket.send(data);
-    console.log('Passing data to client:');
+    if (data.header != null &&
+      data.header.msg_type != null) {
+      socket.emit(data.header.msg_type, data);
+      console.log('Passing data to client on event ' + data.header.msg_type + ':');
+    } else { // fall back
+      console.log('Passing data to client:');
+      socket.send(data);
+    }
     console.log(data);
   });
 


### PR DESCRIPTION
Implemented a few abstractions in Ansible.

python:
Made a new class ansible.AMessage that can be passed into ansible.send and enforces well-formed ansible messages.

node:
Messages in ansible now trigger the socket.io event corresponding to their `msg_type`, with a fallback to `message` otherwise.

Summary:
python:
```python
from ansible import AMessage, send

send(AMessage('important_event', {'important_data': '!!!'}))
```
javascript:
```javascript
ansible.on('important_event', function (message) {
  console.log(message.content);
});
```
would cause javascript to print an object containing
`{"important_data": "!!!"}`