### PR TITLE
Production packaging

### DIFF
--- a/dawn/js/components/DNav.js
+++ b/dawn/js/components/DNav.js
@@ -47,7 +47,7 @@ export default React.createClass({
     });
   },
   getDawnVersion() {
-    return process.env.npm_package_version;
+    return VERSION;
   },
   upgradeSoftware() {
     let defaultLocation = localStorage.getItem('upgradeLocation') || window.location.href;

--- a/dawn/main.js
+++ b/dawn/main.js
@@ -18,7 +18,9 @@ app.on('ready', function() {
   mainWindow.maximize();
 
   mainWindow.loadURL('file://' + __dirname + '/static/index.html');
-  mainWindow.webContents.openDevTools(); // Open dev tools
+  if (process.env.NODE_ENV === 'development') {
+    mainWindow.webContents.openDevTools(); // Open dev tools
+  }
   mainWindow.on('closed', function() {
     mainWindow = null;
   });

--- a/dawn/package.json
+++ b/dawn/package.json
@@ -4,15 +4,30 @@
   "description": "Frontend for PIE Robotics System",
   "main": "main.js",
   "scripts": {
-    "start": "electron main.js",
-    "build": "node ./node_modules/webpack/bin/webpack.js",
+    "start": "better-npm-run start",
+    "build": "better-npm-run build",
     "watch": "node ./node_modules/webpack/bin/webpack.js --watch"
+  },
+  "betterScripts": {
+    "start": {
+      "command": "electron main.js",
+      "env": {
+        "NODE_ENV": "development"
+      }
+    },
+    "build": {
+      "command": "node ./node_modules/webpack/bin/webpack.js -p --config webpack.production.config.js",
+      "env": {
+        "NODE_ENV": "production"
+      }
+    }
   },
   "devDependencies": {
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.2",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "better-npm-run": "0.0.7",
     "webpack": "^1.12.13"
   },
   "dependencies": {

--- a/dawn/webpack.production.config.js
+++ b/dawn/webpack.production.config.js
@@ -20,6 +20,11 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       VERSION: JSON.stringify(require('./package.json').version)
+    }),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': '"production"'
+      }
     })
   ]
 };


### PR DESCRIPTION
Open/close dev tools based on NODE_ENV. Add production webpack config for `npm run-script build`.