### PR TITLE
Save As and Kill Program

### DIFF
--- a/dawn/js/components/Editor.js
+++ b/dawn/js/components/Editor.js
@@ -108,6 +108,9 @@ export default React.createClass({
   saveFile() {
     EditorActionCreators.saveFile(this.state.filepath, this.state.editorCode);
   },
+  saveAsFile() {
+    EditorActionCreators.saveFile(null, this.state.editorCode);
+  },
   createNewFile() {
     if (this.hasUnsavedChanges()) {
       smalltalk.confirm(
@@ -154,7 +157,8 @@ export default React.createClass({
         buttons: [
           new EditorButton('create', 'New', this.createNewFile, 'file'),
           new EditorButton('open', 'Open', this.openFile, 'folder-open'),
-          new EditorButton('save', 'Save', this.saveFile, 'floppy-disk')
+          new EditorButton('save', 'Save', this.saveFile, 'floppy-disk'),
+          new EditorButton('saveas', 'Save As', this.saveAsFile, 'share')
         ],
       }, {
         groupId: 'code-execution-buttons',

--- a/dawn/main.js
+++ b/dawn/main.js
@@ -40,9 +40,7 @@ let template = [
 
 let mainWindow;
 app.on('window-all-closed', function() {
-  if (process.platform != 'darwin') {
-    app.quit();
-  }
+  app.quit();
 });
 
 app.on('ready', function() {


### PR DESCRIPTION
Save As button implemented through Saving New File functionality.

On Macs, closing window kills the program; couldn't restart it anyway.
