### PR TITLE
Display red border for invalid peripheral names

### DIFF
--- a/dawn/js/components/peripherals/NameEdit.js
+++ b/dawn/js/components/peripherals/NameEdit.js
@@ -20,6 +20,15 @@ var NameEdit = React.createClass({
       name: data.name
     });
   },
+  componentDidMount() {
+    // MAJOR HAXORS! The default RIEInput component trims spaces from the
+    // end of strings before passing to validation. But we need
+    // to check for those spaces. So here I am modifying the RIEInput
+    // component's textChanged function to not trim before validation.
+    this.nameEdit.textChanged = (event)=>{
+      this.nameEdit.doValidations(event.target.value);
+    };
+  },
   validatePeripheralName(name) {
     let re = new RegExp("^[A-Za-z][A-Za-z0-9]+$");
     let isValid = re.test(name);
@@ -31,6 +40,7 @@ var NameEdit = React.createClass({
     return (
       <div>
 	<RIEInput
+	  ref={(ref) => this.nameEdit = ref}
 	  className="static"
 	  classEditing="editing"
 	  classInvalid="invalid"

--- a/dawn/js/components/peripherals/NameEdit.js
+++ b/dawn/js/components/peripherals/NameEdit.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import InlineEdit from 'react-edit-inline';
+import {RIEInput} from 'riek';
 import Ansible from '../../utils/Ansible';
 import AlertActions from '../../actions/AlertActions';
 import RobotPeripheralStore from '../../stores/RobotPeripheralStore';
@@ -8,6 +8,11 @@ var NameEdit = React.createClass({
   propTypes: {
     name: React.PropTypes.string,
     id: React.PropTypes.string
+  },
+  shouldComponentUpdate(nextProps) {
+    // By default, the component is constantly being updated which makes
+    // the RIEInput unusable. This prevents unnecessary updating.
+    return nextProps.name !== this.props.name;
   },
   dataChange(data) {
     Ansible.sendMessage('custom_names', {
@@ -25,22 +30,15 @@ var NameEdit = React.createClass({
   render() {
     return (
       <div>
-        <InlineEdit
-          className="static"
-          validate={this.validatePeripheralName}
-          activeClassName="editing"
-          text={this.props.name}
-          change={this.dataChange}
-          paramName="name"
-          style = {{
-            minWidth: 150,
-            borderRadius: '7px',
-            display: 'inline-block',
-            margin: 0,
-            padding: 0,
-            fontSize:15
-          }}
-        />
+	<RIEInput
+	  className="static"
+	  classEditing="editing"
+	  classInvalid="invalid"
+	  validate={this.validatePeripheralName}
+	  value={this.props.name}
+	  change={this.dataChange}
+	  propName="name"
+	/>
       </div>
     );
   }

--- a/dawn/package.json
+++ b/dawn/package.json
@@ -45,8 +45,8 @@
     "react-ace": "^3.0.0",
     "react-bootstrap": "^0.28.1",
     "react-dom": "^0.14.5",
-    "react-edit-inline": "^1.0.6",
     "react-joyride": "^1.1.1",
+    "riek": "^1.0.0",
     "smalltalk": "^1.6.5",
     "superagent": "^1.7.2"
   }

--- a/dawn/static/dawn.css
+++ b/dawn/static/dawn.css
@@ -3,10 +3,15 @@
 }
 
 .editing {
-  width: 0px;
   border: 2px solid #dadada;
   outline: none;
   border-color: #9ecaed;
   box-shadow: 0 0 10px #9ecaed;
 }
 
+.invalid {
+  border: 2px solid #dadada;
+  outline: none;
+  border-color: #ff0000;
+  box-shadow: 0 0 10px #9ecaed;
+}

--- a/dawn/static/dawn.css
+++ b/dawn/static/dawn.css
@@ -1,17 +1,23 @@
 .static:hover {
-  background-color: #f2f2f2;
+  background-color: #cccccc;
 }
 
 .editing {
-  border: 2px solid #dadada;
+  border: 2px solid #9ecaed;
   outline: none;
-  border-color: #9ecaed;
   box-shadow: 0 0 10px #9ecaed;
 }
 
+.editing:hover {
+  background-color: #ffffff;
+}
+
 .invalid {
-  border: 2px solid #dadada;
+  border: 2px solid #ff0000;
   outline: none;
-  border-color: #ff0000;
   box-shadow: 0 0 10px #9ecaed;
+}
+
+.invalid:hover {
+  background-color: #ffffff;
 }


### PR DESCRIPTION
Partially addresses #210 by displaying a red border if the name the user is typing is invalid.

![error](https://cloud.githubusercontent.com/assets/8732147/13619454/f522a4e8-e53d-11e5-8943-8d6a6ded5a57.png)
