### PR TITLE
Stop Warnings about Accessibility

### DIFF
--- a/dawn/js/actions/EditorActionCreators.js
+++ b/dawn/js/actions/EditorActionCreators.js
@@ -8,7 +8,6 @@ let EditorActionCreators = {
   readFilepath(filepath) {
     fs.readFile(filepath, 'utf8', function(err, data) {
       if (err) {
-        console.log('error');
       } else {
         localStorage.setItem('lastFile', filepath);
         AppDispatcher.dispatch({

--- a/dawn/js/components/peripherals/ColorSensor.js
+++ b/dawn/js/components/peripherals/ColorSensor.js
@@ -33,8 +33,8 @@ var ColorSensor = React.createClass({
           <NameEdit name={this.props.name} id={this.props.id} />
           <small> {this.props.peripheralType} </small>
         </h4>
-        <OverlayTrigger trigger="hover" placement="left" overlay={
-          <Popover>
+        <OverlayTrigger trigger={["hover", "focus"]} placement="left" overlay={
+          <Popover id="colors">
             {`R: ${this.props.value[0]} G: ${this.props.value[1]} B: ${this.props.value[2]}`}
             <br/>
             {`Hue: ${numeral(this.props.value[4]).format('0.00')}`}


### PR DESCRIPTION
Don't need an error for not finding a file the first time.

Warnings about id on Popover are fixed, preventing tons of errors.
