### PR TITLE
package.json: Shorten scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "better-npm-run start",
     "build": "better-npm-run build",
-    "lint": "node ./node_modules/eslint/bin/eslint.js -c .eslintrc --ignore-path .eslintignore .",
-    "watch": "node ./node_modules/webpack/bin/webpack.js --watch --progress"
+    "lint": "eslint --config .eslintrc --ignore-path .eslintignore .",
+    "watch": "webpack --watch --progress"
   },
   "betterScripts": {
     "start": {
@@ -17,7 +17,7 @@
       }
     },
     "build": {
-      "command": "node ./node_modules/webpack/bin/webpack.js -p --config webpack.production.config.js",
+      "command": "webpack -p --config webpack.production.config.js",
       "env": {
         "NODE_ENV": "production"
       }


### PR DESCRIPTION
`node_modules/.bin/` is automatically added to PATH, so hardcoded paths are unnecessary.